### PR TITLE
Add Next.js chatbot UI demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 dist
 .env
 .DS_Store
+chatbot-ui/.next
+chatbot-ui/node_modules
+chatbot-ui/.turbo

--- a/chatbot-ui/app/api/chat/route.ts
+++ b/chatbot-ui/app/api/chat/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { messages } = body;
+
+  const lastMessage = messages?.at?.(-1)?.content ?? '';
+  const reply =
+    typeof lastMessage === 'string' && lastMessage.trim().length > 0
+      ? `You said: ${lastMessage}`
+      : 'Hello from the mock API!';
+
+  return NextResponse.json({
+    id: 'mock-response',
+    role: 'assistant',
+    content: reply,
+  });
+}

--- a/chatbot-ui/app/globals.css
+++ b/chatbot-ui/app/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 255 255 255;
+  --foreground: 17 24 39;
+}
+
+body {
+  color: rgb(var(--foreground));
+  background: rgb(var(--background));
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}

--- a/chatbot-ui/app/layout.tsx
+++ b/chatbot-ui/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'AI Elements Chatbot',
+  description: 'Simple chatbot UI using Vercel AI SDK 5 and AI Elements-inspired components.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/chatbot-ui/app/page.tsx
+++ b/chatbot-ui/app/page.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { Fragment, useMemo, useState } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { GlobeIcon, CopyIcon, RefreshCcwIcon } from 'lucide-react';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai-elements/conversation';
+import { Message, MessageContent } from '@/components/ai-elements/message';
+import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
+import {
+  PromptInput,
+  PromptInputActionAddAttachments,
+  PromptInputActionMenu,
+  PromptInputActionMenuContent,
+  PromptInputActionMenuTrigger,
+  PromptInputAttachment,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputButton,
+  PromptInputModelSelect,
+  PromptInputModelSelectContent,
+  PromptInputModelSelectItem,
+  PromptInputModelSelectTrigger,
+  PromptInputModelSelectValue,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+  PromptInputTools,
+} from '@/components/ai-elements/prompt-input';
+import { Actions, Action } from '@/components/ai-elements/actions';
+import { Response } from '@/components/ai-elements/response';
+import {
+  Source,
+  Sources,
+  SourcesContent,
+  SourcesTrigger,
+} from '@/components/ai-elements/sources';
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from '@/components/ai-elements/reasoning';
+import { Loader } from '@/components/ai-elements/loader';
+
+type MessagePart =
+  | { type: 'text'; text: string }
+  | { type: 'source-url'; url: string }
+  | { type: 'reasoning'; text: string };
+
+type UIMessage = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  parts: MessagePart[];
+};
+
+const models = [
+  {
+    name: 'GPT 4o',
+    value: 'openai/gpt-4o',
+  },
+  {
+    name: 'Deepseek R1',
+    value: 'deepseek/deepseek-r1',
+  },
+];
+
+const SAMPLE_SOURCES = [
+  'https://example.com/article',
+  'https://example.com/docs',
+];
+
+export default function ChatBotDemo() {
+  const [input, setInput] = useState('');
+  const [model, setModel] = useState<string>(models[0].value);
+  const [webSearch, setWebSearch] = useState(false);
+  const { messages, sendMessage, status } = useChat({ api: '/api/chat' });
+
+  const normalizedMessages: UIMessage[] = useMemo(() => {
+    if (!messages.length) {
+      return [
+        {
+          id: 'assistant-welcome',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'Hi there! Ask me anything or try attaching a file to the prompt input.',
+            },
+            {
+              type: 'reasoning',
+              text: 'This is a static reasoning trace to demonstrate the disclosure UI.',
+            },
+            ...SAMPLE_SOURCES.map<MessagePart>((url) => ({ type: 'source-url', url })),
+          ],
+        },
+      ];
+    }
+
+    return messages.map((message) => {
+      const maybeParts = (message as unknown as { parts?: MessagePart[] }).parts;
+      if (Array.isArray(maybeParts) && maybeParts.length > 0) {
+        return {
+          id: message.id,
+          role: message.role,
+          parts: maybeParts,
+        } satisfies UIMessage;
+      }
+
+      const content = Array.isArray(message.content)
+        ? message.content.map((part) =>
+            typeof part === 'string'
+              ? { type: 'text', text: part }
+              : { type: 'text', text: String(part) },
+          )
+        : [{ type: 'text', text: typeof message.content === 'string' ? message.content : JSON.stringify(message.content) }];
+      return {
+        id: message.id,
+        role: message.role,
+        parts: content,
+      } satisfies UIMessage;
+    });
+  }, [messages]);
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    const hasText = Boolean(message.text?.trim());
+    const hasAttachments = Boolean(message.files?.length);
+
+    if (!(hasText || hasAttachments)) {
+      return;
+    }
+
+    sendMessage(
+      {
+        text: message.text || 'Sent with attachments',
+      },
+      {
+        body: {
+          model,
+          webSearch,
+        },
+      },
+    );
+    setInput('');
+  };
+
+  const handleRetry = () => {
+    const lastUserMessage = messages.filter((msg) => msg.role === 'user').at(-1);
+    if (!lastUserMessage) {
+      return;
+    }
+    const text = Array.isArray(lastUserMessage.content)
+      ? lastUserMessage.content.join(' ')
+      : typeof lastUserMessage.content === 'string'
+        ? lastUserMessage.content
+        : '';
+    if (!text.trim()) {
+      return;
+    }
+    sendMessage(
+      { text },
+      {
+        body: {
+          model,
+          webSearch,
+        },
+      },
+    );
+  };
+
+  const latestAssistantMessage = normalizedMessages.filter((msg) => msg.role === 'assistant').at(-1);
+
+  return (
+    <div className="mx-auto flex h-screen max-w-4xl flex-col p-6">
+      <Conversation className="flex-1 overflow-hidden">
+        <ConversationContent>
+          {normalizedMessages.map((message, index) => (
+            <div key={message.id} className="space-y-2">
+              {message.role === 'assistant' &&
+                message.parts.filter((part) => part.type === 'source-url').length > 0 && (
+                  <Sources>
+                    <SourcesTrigger
+                      count={message.parts.filter((part) => part.type === 'source-url').length}
+                    />
+                    {message.parts
+                      .filter((part): part is Extract<MessagePart, { type: 'source-url' }> => part.type === 'source-url')
+                      .map((part, i) => (
+                        <SourcesContent key={`${message.id}-source-${i}`}>
+                          <Source href={part.url} title={part.url} />
+                        </SourcesContent>
+                      ))}
+                  </Sources>
+                )}
+
+              {message.parts.map((part, partIndex) => {
+                switch (part.type) {
+                  case 'text':
+                    return (
+                      <Fragment key={`${message.id}-${partIndex}`}>
+                        <Message from={message.role}>
+                          <MessageContent from={message.role}>
+                            <Response>{part.text}</Response>
+                          </MessageContent>
+                        </Message>
+                        {message.role === 'assistant' &&
+                          latestAssistantMessage?.id === message.id &&
+                          partIndex === message.parts.length - 1 && (
+                            <Actions className="mt-2">
+                              <Action label="Retry" onClick={() => handleRetry()}>
+                                <RefreshCcwIcon className="h-3 w-3" />
+                              </Action>
+                              <Action
+                                label="Copy"
+                                onClick={() => navigator.clipboard.writeText(part.text)}
+                              >
+                                <CopyIcon className="h-3 w-3" />
+                              </Action>
+                            </Actions>
+                          )}
+                      </Fragment>
+                    );
+                  case 'reasoning':
+                    return (
+                      <Reasoning
+                        key={`${message.id}-${partIndex}`}
+                        className="w-full"
+                        isStreaming={status === 'streaming' && index === normalizedMessages.length - 1}
+                      >
+                        <ReasoningTrigger />
+                        <ReasoningContent>{part.text}</ReasoningContent>
+                      </Reasoning>
+                    );
+                  case 'source-url':
+                    return null;
+                  default:
+                    return null;
+                }
+              })}
+            </div>
+          ))}
+          {status === 'submitted' && <Loader />}
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+
+      <PromptInput onSubmit={handleSubmit} className="mt-4" globalDrop multiple>
+        <PromptInputBody>
+          <PromptInputAttachments>
+            {(attachment) => <PromptInputAttachment data={attachment} />}
+          </PromptInputAttachments>
+          <PromptInputTextarea onChange={(event) => setInput(event.target.value)} value={input} />
+        </PromptInputBody>
+        <PromptInputToolbar>
+          <PromptInputTools>
+            <PromptInputActionMenu>
+              <PromptInputActionMenuTrigger />
+              <PromptInputActionMenuContent>
+                <PromptInputActionAddAttachments />
+              </PromptInputActionMenuContent>
+            </PromptInputActionMenu>
+            <PromptInputButton
+              onClick={() => setWebSearch(!webSearch)}
+              aria-pressed={webSearch}
+              className={webSearch ? 'bg-slate-900 text-white hover:bg-slate-800' : undefined}
+            >
+              <GlobeIcon size={16} />
+              <span>Search</span>
+            </PromptInputButton>
+            <PromptInputModelSelect
+              value={model}
+              onValueChange={(value) => {
+                setModel(value);
+              }}
+            >
+              <PromptInputModelSelectTrigger>
+                <PromptInputModelSelectValue>
+                  {models.find((item) => item.value === model)?.name ?? model}
+                </PromptInputModelSelectValue>
+              </PromptInputModelSelectTrigger>
+              <PromptInputModelSelectContent>
+                {models.map((model) => (
+                  <PromptInputModelSelectItem key={model.value} value={model.value}>
+                    {model.name}
+                  </PromptInputModelSelectItem>
+                ))}
+              </PromptInputModelSelectContent>
+            </PromptInputModelSelect>
+          </PromptInputTools>
+          <PromptInputSubmit status={status} />
+        </PromptInputToolbar>
+      </PromptInput>
+    </div>
+  );
+}

--- a/chatbot-ui/components/ai-elements/actions.tsx
+++ b/chatbot-ui/components/ai-elements/actions.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+interface ActionsContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const ActionsContext = createContext<ActionsContextValue | null>(null);
+
+export function Actions({ className, children }: HTMLAttributes<HTMLDivElement>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <ActionsContext.Provider value={{ open, setOpen }}>
+      <div className={cn('relative flex items-center gap-2', className)}>{children}</div>
+    </ActionsContext.Provider>
+  );
+}
+
+export function Action({ label, onClick, children }: { label: string; onClick?: () => void; children: ReactNode }) {
+  return (
+    <button
+      type="button"
+      className="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+      onClick={onClick}
+      aria-label={label}
+    >
+      {children}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function ActionsTrigger({ children, className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const context = useContext(ActionsContext);
+  if (!context) {
+    throw new Error('ActionsTrigger must be used within Actions');
+  }
+  return (
+    <button
+      type="button"
+      className={cn('rounded-md border border-slate-200 bg-white px-2 py-1 text-xs', className)}
+      onClick={() => context.setOpen(!context.open)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ActionsContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const context = useContext(ActionsContext);
+  if (!context) {
+    throw new Error('ActionsContent must be used within Actions');
+  }
+  if (!context.open) {
+    return null;
+  }
+  return (
+    <div
+      className={cn('absolute right-0 top-full z-10 mt-2 min-w-[12rem] rounded-md border border-slate-200 bg-white p-2 shadow-lg', className)}
+      {...props}
+    />
+  );
+}

--- a/chatbot-ui/components/ai-elements/conversation.tsx
+++ b/chatbot-ui/components/ai-elements/conversation.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {
+  useEffect,
+  useRef,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+type ConversationProps = HTMLAttributes<HTMLDivElement>;
+
+export function Conversation({ className, ...props }: ConversationProps) {
+  return <div className={cn('flex flex-col gap-4', className)} {...props} />;
+}
+
+export function ConversationContent({ className, ...props }: ConversationProps) {
+  return <div className={cn('flex-1 overflow-y-auto space-y-4 pr-2', className)} {...props} />;
+}
+
+export function ConversationScrollButton({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const scrollRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  });
+
+  return (
+    <button
+      ref={scrollRef}
+      type="button"
+      className={cn('sr-only', className)}
+      aria-hidden
+      tabIndex={-1}
+      {...props}
+    />
+  );
+}

--- a/chatbot-ui/components/ai-elements/loader.tsx
+++ b/chatbot-ui/components/ai-elements/loader.tsx
@@ -1,0 +1,8 @@
+export function Loader() {
+  return (
+    <div className="flex items-center justify-center py-4 text-sm text-slate-500">
+      <span className="h-2 w-2 animate-ping rounded-full bg-slate-400" aria-hidden />
+      <span className="ml-2">Thinking…</span>
+    </div>
+  );
+}

--- a/chatbot-ui/components/ai-elements/message.tsx
+++ b/chatbot-ui/components/ai-elements/message.tsx
@@ -1,0 +1,28 @@
+import { type HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+interface MessageProps extends HTMLAttributes<HTMLDivElement> {
+  from: 'user' | 'assistant' | string;
+}
+
+export function Message({ from, className, ...props }: MessageProps) {
+  const alignment = from === 'user' ? 'items-end' : 'items-start';
+  return (
+    <div className={cn('flex flex-col gap-2', alignment, className)} {...props} />
+  );
+}
+
+interface MessageContentProps extends HTMLAttributes<HTMLDivElement> {
+  from?: 'user' | 'assistant' | string;
+}
+
+export function MessageContent({ from, className, ...props }: MessageContentProps) {
+  const baseStyles = 'text-sm leading-relaxed text-slate-900 dark:text-slate-100';
+  const variantStyles =
+    from === 'user'
+      ? 'max-w-[75%] rounded-2xl bg-slate-200 px-4 py-2 text-slate-900 shadow-sm dark:bg-slate-800 dark:text-slate-100'
+      : 'max-w-[75%]';
+  return (
+    <div className={cn(baseStyles, variantStyles, className)} {...props} />
+  );
+}

--- a/chatbot-ui/components/ai-elements/prompt-input.tsx
+++ b/chatbot-ui/components/ai-elements/prompt-input.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ButtonHTMLAttributes,
+  type Dispatch,
+  type FormHTMLAttributes,
+  type HTMLAttributes,
+  type LabelHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+  type SetStateAction,
+  type TextareaHTMLAttributes,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+type FileData = File;
+
+export type PromptInputMessage = {
+  text?: string;
+  files?: FileData[];
+};
+
+type PromptInputContextValue = {
+  text: string;
+  setText: (value: string) => void;
+  files: FileData[];
+  setFiles: Dispatch<SetStateAction<FileData[]>>;
+};
+
+const PromptInputContext = createContext<PromptInputContextValue | null>(null);
+
+interface PromptInputProps extends FormHTMLAttributes<HTMLFormElement> {
+  onSubmit: (message: PromptInputMessage) => void;
+  globalDrop?: boolean;
+  multiple?: boolean;
+}
+
+export function PromptInput({ className, children, onSubmit, ...props }: PromptInputProps) {
+  const [text, setText] = useState('');
+  const [files, setFiles] = useState<FileData[]>([]);
+
+  return (
+    <form
+      className={cn('rounded-xl border border-slate-200 bg-white shadow-sm', className)}
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit({ text, files });
+        setText('');
+        setFiles([]);
+      }}
+      {...props}
+    >
+      <PromptInputContext.Provider value={{ text, setText, files, setFiles }}>
+        {children}
+      </PromptInputContext.Provider>
+    </form>
+  );
+}
+
+export function PromptInputBody({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-4', className)} {...props} />;
+}
+
+export function PromptInputTextarea({ className, onChange, value = '', ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  const context = usePromptInputContext();
+  useEffect(() => {
+    context.setText(value.toString());
+  }, [value, context]);
+  return (
+    <textarea
+      className={cn('min-h-[80px] w-full resize-none rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400', className)}
+      onChange={(event) => {
+        context.setText(event.target.value);
+        onChange?.(event);
+      }}
+      value={value}
+      {...props}
+    />
+  );
+}
+
+interface PromptInputAttachmentsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  children: (file: FileData) => ReactNode;
+}
+
+export function PromptInputAttachments({ className, children, ...props }: PromptInputAttachmentsProps) {
+  const context = usePromptInputContext();
+  if (context.files.length === 0) {
+    return null;
+  }
+  return (
+    <div className={cn('mb-2 flex flex-wrap gap-2', className)} {...props}>
+      {context.files.map((file, index) => (
+        <div key={`${file.name}-${index}`}>{children(file)}</div>
+      ))}
+    </div>
+  );
+}
+
+export function PromptInputAttachment({ data }: { data: FileData }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-dashed border-slate-300 px-2 py-1 text-xs text-slate-600">
+      <span className="truncate">{data.name}</span>
+    </div>
+  );
+}
+
+export function PromptInputToolbar({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-2', className)} {...props} />
+  );
+}
+
+export function PromptInputTools({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex items-center gap-2', className)} {...props} />;
+}
+
+export function PromptInputButton({ className, children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      className={cn('flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100', className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function PromptInputSubmit({ status, className, disabled, ...props }: ButtonHTMLAttributes<HTMLButtonElement> & { status?: string | null }) {
+  const context = usePromptInputContext();
+  const isStreaming = status === 'streaming';
+  const shouldDisable =
+    typeof disabled === 'boolean'
+      ? disabled
+      : !isStreaming && context.text.trim().length === 0 && context.files.length === 0;
+  return (
+    <button
+      type="submit"
+      className={cn('rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50', className)}
+      disabled={shouldDisable}
+      {...props}
+    >
+      {isStreaming ? 'Stop' : 'Send'}
+    </button>
+  );
+}
+
+const PromptInputActionMenuContext = createContext<{
+  open: boolean;
+  setOpen: (value: boolean) => void;
+} | null>(null);
+
+export function PromptInputActionMenu({ className, children }: HTMLAttributes<HTMLDivElement>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <PromptInputActionMenuContext.Provider value={{ open, setOpen }}>
+      <div className={cn('relative', className)}>{children}</div>
+    </PromptInputActionMenuContext.Provider>
+  );
+}
+
+export function PromptInputActionMenuTrigger({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const context = useContext(PromptInputActionMenuContext);
+  if (!context) {
+    throw new Error('PromptInputActionMenuTrigger must be used within PromptInputActionMenu');
+  }
+  return (
+    <button
+      type="button"
+      className={cn('rounded-md border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-700 shadow-sm', className)}
+      onClick={() => context.setOpen(!context.open)}
+      {...props}
+    >
+      ⋮
+    </button>
+  );
+}
+
+export function PromptInputActionMenuContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const context = useContext(PromptInputActionMenuContext);
+  if (!context?.open) {
+    return null;
+  }
+  return (
+    <div className={cn('absolute bottom-full left-0 mb-2 w-48 rounded-md border border-slate-200 bg-white p-2 text-xs shadow-lg', className)} {...props} />
+  );
+}
+
+interface PromptInputActionAddAttachmentsProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 'children'> {
+  children?: ReactNode;
+}
+
+export function PromptInputActionAddAttachments({ className, children, ...props }: PromptInputActionAddAttachmentsProps) {
+  const context = usePromptInputContext();
+  return (
+    <label
+      className={cn('flex cursor-pointer items-center gap-2 rounded-md border border-dashed border-slate-300 px-2 py-1 text-xs text-slate-600', className)}
+      {...props}
+    >
+      <input
+        type="file"
+        className="hidden"
+        multiple
+        onChange={(event) => {
+          const files = Array.from(event.target.files ?? []);
+          if (files.length) {
+            context.setFiles((prev) => [...prev, ...files]);
+          }
+        }}
+      />
+      {children ?? <span>Add attachment</span>}
+    </label>
+  );
+}
+
+export function PromptInputModelSelect({ children, value, onValueChange, className }: {
+  children: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn('relative', className)}>
+      {children}
+      <select
+        className="absolute inset-0 opacity-0"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+      >
+        {extractItems(children)}
+      </select>
+    </div>
+  );
+}
+
+function extractItems(children: ReactNode): ReactNode {
+  const items: ReactNode[] = [];
+  const traverse = (node: ReactNode) => {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      node.forEach(traverse);
+      return;
+    }
+    if (typeof node === 'object' && 'props' in (node as any)) {
+      const element = node as ReactElement;
+      if (element.type === PromptInputModelSelectItem) {
+        items.push(
+          <option key={element.props.value} value={element.props.value}>
+            {element.props.children}
+          </option>,
+        );
+      }
+      traverse(element.props.children);
+    }
+  };
+  traverse(children);
+  return items;
+}
+
+export function PromptInputModelSelectTrigger({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export function PromptInputModelSelectValue({ className, children, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span className={cn('text-xs font-medium text-slate-700', className)} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export function PromptInputModelSelectContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('hidden', className)} {...props} />;
+}
+
+export function PromptInputModelSelectItem({ className, children, value }: { className?: string; children: ReactNode; value: string }) {
+  return (
+    <div className={cn('px-3 py-1 text-xs text-slate-600', className)} data-value={value}>
+      {children}
+    </div>
+  );
+}
+
+function usePromptInputContext() {
+  const context = useContext(PromptInputContext);
+  if (!context) {
+    throw new Error('PromptInput components must be used within PromptInput');
+  }
+  return context;
+}

--- a/chatbot-ui/components/ai-elements/reasoning.tsx
+++ b/chatbot-ui/components/ai-elements/reasoning.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+interface ReasoningContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  isStreaming?: boolean;
+}
+
+const ReasoningContext = createContext<ReasoningContextValue | null>(null);
+
+interface ReasoningProps extends HTMLAttributes<HTMLDivElement> {
+  isStreaming?: boolean;
+}
+
+export function Reasoning({ className, children, isStreaming, ...props }: ReasoningProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <ReasoningContext.Provider value={{ open, setOpen, isStreaming }}>
+      <div className={cn('flex flex-col gap-2', className)} {...props}>
+        {children}
+      </div>
+    </ReasoningContext.Provider>
+  );
+}
+
+export function ReasoningTrigger({ className, children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const context = useReasoningContext();
+  const label = context.open ? 'Hide reasoning' : 'Show reasoning';
+  return (
+    <button
+      type="button"
+      className={cn('inline-flex items-center gap-2 self-start rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm', className)}
+      onClick={() => context.setOpen(!context.open)}
+      {...props}
+    >
+      {children ?? label}
+      {context.isStreaming && (
+        <span className="text-[10px] font-semibold text-emerald-600">Streaming…</span>
+      )}
+    </button>
+  );
+}
+
+export function ReasoningContent({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const context = useReasoningContext();
+  if (!context.open) {
+    return null;
+  }
+  return (
+    <div className={cn('rounded-md border border-slate-200 bg-slate-50 p-3 text-xs text-slate-700', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function useReasoningContext() {
+  const context = useContext(ReasoningContext);
+  if (!context) {
+    throw new Error('Reasoning components must be used within Reasoning');
+  }
+  return context;
+}

--- a/chatbot-ui/components/ai-elements/response.tsx
+++ b/chatbot-ui/components/ai-elements/response.tsx
@@ -1,0 +1,6 @@
+import { type HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Response({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('leading-relaxed', className)} {...props} />;
+}

--- a/chatbot-ui/components/ai-elements/sources.tsx
+++ b/chatbot-ui/components/ai-elements/sources.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+interface SourcesContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const SourcesContext = createContext<SourcesContextValue | null>(null);
+
+export function Sources({ className, children }: HTMLAttributes<HTMLDivElement>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <SourcesContext.Provider value={{ open, setOpen }}>
+      <div className={cn('relative flex flex-col gap-2', className)}>{children}</div>
+    </SourcesContext.Provider>
+  );
+}
+
+export function SourcesTrigger({ count, className, ...props }: ButtonHTMLAttributes<HTMLButtonElement> & { count: number }) {
+  const context = useSourcesContext();
+  return (
+    <button
+      type="button"
+      className={cn('inline-flex items-center gap-2 self-start rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm', className)}
+      onClick={() => context.setOpen(!context.open)}
+      {...props}
+    >
+      Sources ({count})
+    </button>
+  );
+}
+
+export function SourcesContent({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  const context = useSourcesContext();
+  if (!context.open) {
+    return null;
+  }
+  return (
+    <div className={cn('flex flex-col gap-2 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-sm', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function Source({ href, title }: { href: string; title: string }) {
+  return (
+    <a className="truncate text-xs font-medium text-slate-700 underline" href={href} target="_blank" rel="noreferrer">
+      {title}
+    </a>
+  );
+}
+
+function useSourcesContext() {
+  const context = useContext(SourcesContext);
+  if (!context) {
+    throw new Error('Sources components must be used within Sources');
+  }
+  return context;
+}

--- a/chatbot-ui/lib/utils.ts
+++ b/chatbot-ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/chatbot-ui/next-env.d.ts
+++ b/chatbot-ui/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/chatbot-ui/next.config.mjs
+++ b/chatbot-ui/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/chatbot-ui/package.json
+++ b/chatbot-ui/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "chatbot-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@ai-sdk/react": "^0.0.55",
+    "ai": "^3.2.33",
+    "autoprefixer": "^10.4.20",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.451.0",
+    "next": "^14.2.5",
+    "postcss": "^8.4.47",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.2",
+    "tailwindcss": "^3.4.13",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^14.2.5",
+    "typescript": "^5.5.4"
+  }
+}

--- a/chatbot-ui/postcss.config.mjs
+++ b/chatbot-ui/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/chatbot-ui/tailwind.config.ts
+++ b/chatbot-ui/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/chatbot-ui/tsconfig.json
+++ b/chatbot-ui/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a standalone Next.js 14 project that scaffolds a chat UI using Vercel AI SDK 5 hooks and AI Elements-inspired components
- implement reusable UI primitives for conversation, prompt input, actions, sources, reasoning, and loading states to mirror the example layout
- include minimal styling, Tailwind configuration, and a mock `/api/chat` route to echo user input for local prototyping
- adjust chat message styling so only user messages render in a grey bubble while assistant replies are unframed text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d889a6b8e883228c1f68629aead873