### PR TITLE
Remove extra prompt input controls and round input styling

### DIFF
--- a/chatbot-ui/app/page.tsx
+++ b/chatbot-ui/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
-import { GlobeIcon, CopyIcon, RefreshCcwIcon } from 'lucide-react';
+import { CopyIcon, RefreshCcwIcon } from 'lucide-react';
 import {
   Conversation,
   ConversationContent,
@@ -12,19 +12,9 @@ import { Message, MessageContent } from '@/components/ai-elements/message';
 import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
 import {
   PromptInput,
-  PromptInputActionAddAttachments,
-  PromptInputActionMenu,
-  PromptInputActionMenuContent,
-  PromptInputActionMenuTrigger,
   PromptInputAttachment,
   PromptInputAttachments,
   PromptInputBody,
-  PromptInputButton,
-  PromptInputModelSelect,
-  PromptInputModelSelectContent,
-  PromptInputModelSelectItem,
-  PromptInputModelSelectTrigger,
-  PromptInputModelSelectValue,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
@@ -56,16 +46,8 @@ type UIMessage = {
   parts: MessagePart[];
 };
 
-const models = [
-  {
-    name: 'GPT 4o',
-    value: 'openai/gpt-4o',
-  },
-  {
-    name: 'Deepseek R1',
-    value: 'deepseek/deepseek-r1',
-  },
-];
+const DEFAULT_MODEL = 'openai/gpt-4o';
+const DEFAULT_WEB_SEARCH = false;
 
 const SAMPLE_SOURCES = [
   'https://example.com/article',
@@ -74,8 +56,6 @@ const SAMPLE_SOURCES = [
 
 export default function ChatBotDemo() {
   const [input, setInput] = useState('');
-  const [model, setModel] = useState<string>(models[0].value);
-  const [webSearch, setWebSearch] = useState(false);
   const { messages, sendMessage, status } = useChat({ api: '/api/chat' });
 
   const normalizedMessages: UIMessage[] = useMemo(() => {
@@ -138,8 +118,8 @@ export default function ChatBotDemo() {
       },
       {
         body: {
-          model,
-          webSearch,
+          model: DEFAULT_MODEL,
+          webSearch: DEFAULT_WEB_SEARCH,
         },
       },
     );
@@ -163,8 +143,8 @@ export default function ChatBotDemo() {
       { text },
       {
         body: {
-          model,
-          webSearch,
+          model: DEFAULT_MODEL,
+          webSearch: DEFAULT_WEB_SEARCH,
         },
       },
     );
@@ -253,41 +233,7 @@ export default function ChatBotDemo() {
           <PromptInputTextarea onChange={(event) => setInput(event.target.value)} value={input} />
         </PromptInputBody>
         <PromptInputToolbar>
-          <PromptInputTools>
-            <PromptInputActionMenu>
-              <PromptInputActionMenuTrigger />
-              <PromptInputActionMenuContent>
-                <PromptInputActionAddAttachments />
-              </PromptInputActionMenuContent>
-            </PromptInputActionMenu>
-            <PromptInputButton
-              onClick={() => setWebSearch(!webSearch)}
-              aria-pressed={webSearch}
-              className={webSearch ? 'bg-slate-900 text-white hover:bg-slate-800' : undefined}
-            >
-              <GlobeIcon size={16} />
-              <span>Search</span>
-            </PromptInputButton>
-            <PromptInputModelSelect
-              value={model}
-              onValueChange={(value) => {
-                setModel(value);
-              }}
-            >
-              <PromptInputModelSelectTrigger>
-                <PromptInputModelSelectValue>
-                  {models.find((item) => item.value === model)?.name ?? model}
-                </PromptInputModelSelectValue>
-              </PromptInputModelSelectTrigger>
-              <PromptInputModelSelectContent>
-                {models.map((model) => (
-                  <PromptInputModelSelectItem key={model.value} value={model.value}>
-                    {model.name}
-                  </PromptInputModelSelectItem>
-                ))}
-              </PromptInputModelSelectContent>
-            </PromptInputModelSelect>
-          </PromptInputTools>
+          <PromptInputTools />
           <PromptInputSubmit status={status} />
         </PromptInputToolbar>
       </PromptInput>

--- a/chatbot-ui/components/ai-elements/prompt-input.tsx
+++ b/chatbot-ui/components/ai-elements/prompt-input.tsx
@@ -45,7 +45,7 @@ export function PromptInput({ className, children, onSubmit, ...props }: PromptI
 
   return (
     <form
-      className={cn('rounded-xl border border-slate-200 bg-white shadow-sm', className)}
+      className={cn('rounded-3xl border border-slate-200 bg-white shadow-sm', className)}
       onSubmit={(event) => {
         event.preventDefault();
         onSubmit({ text, files });
@@ -72,7 +72,7 @@ export function PromptInputTextarea({ className, onChange, value = '', ...props 
   }, [value, context]);
   return (
     <textarea
-      className={cn('min-h-[80px] w-full resize-none rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400', className)}
+      className={cn('min-h-[80px] w-full resize-none rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400', className)}
       onChange={(event) => {
         context.setText(event.target.value);
         onChange?.(event);
@@ -141,7 +141,7 @@ export function PromptInputSubmit({ status, className, disabled, ...props }: But
   return (
     <button
       type="submit"
-      className={cn('rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50', className)}
+      className={cn('rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50', className)}
       disabled={shouldDisable}
       {...props}
     >


### PR DESCRIPTION
## Summary
- remove the search toggle, model picker, and action menu from the prompt toolbar
- keep chat requests on the default model while simplifying request metadata
- round the prompt container, textarea, and submit button for a softer appearance

## Testing
- npm run lint *(fails: next binary unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d89121beb4832293ffb0e8bf343a4e